### PR TITLE
Add AWS Whitepapers to AWS Learning Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 ## AWS Learning Resources
 - [AWS Skill Builder](https://skillbuilder.aws/)
 - [AWS Free Tier](https://aws.amazon.com/free/)
+- [AWS Whitepapers](https://aws.amazon.com/whitepapers/)
 
 ## Typing Games
 - [ZType](https://zty.pe/)


### PR DESCRIPTION
### Resource Name and Link

**Resource Name**: AWS Whitepapers
**Resource Link**: `https://aws.amazon.com/whitepapers/`  

---

### Resource Category

**Category**: AWS Learning Resources

---

- [x] I have read and followed the [Contribution Guidelines].  
- [x] The resource is relevant and useful for development purposes.  
- [x] I have added the resource to the appropriate section in `README.md`. 